### PR TITLE
Add tuning-fork to Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [waveform-path](https://github.com/jerosoler/waveform-path) - Library to generate waveforms paths in svg.
 - [wave-audio-path-player](https://github.com/jerosoler/wave-audio-path-player) - Simple audio player webcomponent customizable with waveform.
 - [dsssp](https://github.com/NumberOneBot/dsssp) - React component library for visualizing and managing audio filters with drag-n-drop and transitions support.
+- [tuning-fork](https://github.com/v-rusu/tuning-fork) - A configurable client-side JavaScript library for guitar tuning with real-time pitch detection.
 
 ### Utilities
 


### PR DESCRIPTION
tuning-fork is a real-time pitch detection library used for tuning string instruments. Supports standard and alternate tunings for guitar, bass, ukulele, banjo, and custom instruments.