### PR TITLE
Add PracticeLoop - YouTube practice tool with Web Audio features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,8 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) – Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - .[synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [online decibel meter](https://realtimesoundmeter.org/) – Free online sound meter to measure environmental noise levels in decibels (dB). Real-time sound level meter for detecting quiet, noisy, or harmful sound levels.
-  
+- [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/) - Free YouTube looper with progressive speed training, metronome, and chromatic tuner for music practice.
+
 ## Resources
 
 ### Tutorials


### PR DESCRIPTION
Hi! I'd like to suggest adding **PracticeLoop** to the Apps section.

**Tool:** [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/)

**Description:** Free YouTube looper with progressive speed training, built-in metronome, and chromatic tuner.

**Why it fits:**
- Uses Web Audio API for chromatic tuner (pitch detection via analyser node)
- Combines YouTube playback control (speed, A-B loop) with Web Audio features
- Progressive speed training: auto-increments playback speed after N loop reps
- Built-in metronome using Web Audio oscillator and gain nodes
- Targets deliberate practice methodology for musicians

**Key features:**
- Speed control (0.25x-2x) with A-B looping
- Chromatic tuner with real-time pitch detection
- Metronome with tap tempo
- Practice timer with session tracking
- PWA support

Thanks for maintaining this list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PracticeLoop to the applications list, a free YouTube looper featuring progressive speed training, metronome, and chromatic tuner functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->