### PR TITLE
Add keystrum – QWERTY strum instrument with Karplus-Strong synthesis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - .[synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [online decibel meter](https://realtimesoundmeter.org/) – Free online sound meter to measure environmental noise levels in decibels (dB). Real-time sound level meter for detecting quiet, noisy, or harmful sound levels.
 - [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/) - Free YouTube looper with progressive speed training, metronome, and chromatic tuner for music practice.
+- [keystrum](https://keystrum.app) ([source](https://github.com/kimhinton/keystrum)) - A browser instrument that turns a QWERTY keyboard into a strum machine using Karplus-Strong synthesis. No samples loaded.
 
 ## Resources
 


### PR DESCRIPTION
Adds [keystrum](https://keystrum.app) to the **Apps** section.

keystrum is an MIT-licensed, browser-based instrument that maps QWERTY keyboard
columns to chords (Am, C, Em, G, Dm, F). Sweeping a column of keys within 90 ms
is detected as a strum — downstroke or upstroke depending on direction. All sound
is generated live with Karplus-Strong physical modeling via the Web Audio API; no
samples are loaded.

It also includes a practice mode with three folk songs and a chord dictionary.

- Live: https://keystrum.app
- Source: https://github.com/kimhinton/keystrum
- npm: [@keystrum/synth](https://www.npmjs.com/package/@keystrum/synth), [@keystrum/layout](https://www.npmjs.com/package/@keystrum/layout)
- License: MIT
- Tech: Web Audio API (Karplus-Strong), Next.js, TypeScript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added keystrum to the Apps catalog - a browser-based strum machine instrument using Karplus-Strong synthesis technology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->