### PR TITLE
Add Vizz.fm to Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Drumhaus](https://drumha.us/) – a browser-based drum machine with step sequencing, pattern variations, and groove editing.
 - [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) – Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
+- [Vizz.fm](https://vizz.fm) - Browser-based music visualizer for mic, file, stream, or system audio with customizable scenes and presets.
 
 ## Resources
 


### PR DESCRIPTION
Adds Vizz.fm - a free, web-audio powered customizable music visualizer useful for streaming

<img width="1802" height="1354" alt="mesh-grid" src="https://github.com/user-attachments/assets/a91daac7-4c9f-4c48-a5c3-87af902fbf53" />
<img width="1040" height="720" alt="spherical-shader" src="https://github.com/user-attachments/assets/36f68e2d-2411-4946-afc2-1e9444371114" />
<img width="2202" height="1282" alt="waveform" src="https://github.com/user-attachments/assets/d3ed9e28-5e92-4bc2-94fb-ae70cc416b80" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Apps entry for Vizz.fm, including its link and a short description. This is a small documentation update that makes Vizz.fm discoverable in the Apps listing for end users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/notthetup/awesome-webaudio/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->