### PR TITLE
Add ToolKnit MIDI Keyboard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-ï»¿# Awesome WebAudio
+# Awesome WebAudio
 
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/sindresorhus/awesome#readme)
 
@@ -33,7 +33,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Bap](https://github.com/adamrenklint/bap) - A toolkit for making beats and composing sequences, inspired by the classic MPC60/2000.
 - [Omnitone](https://github.com/GoogleChrome/omnitone) - Ambisonic spatial audio on the web.
 - [Mach1Spatial](https://github.com/Mach1Studios/m1-sdk) - Vector based panning spatial audio on the web.
-- [Elementary](https://www.elementary.audio/) â€“Â Declarative, functional framework for writing audio software on the web or for native apps
+- [Elementary](https://www.elementary.audio/) ¨C?Declarative, functional framework for writing audio software on the web or for native apps
 - [React Native Audio API](https://github.com/software-mansion-labs/react-native-audio-api) - Web Audio API implementation for native apps based on react-native.
 
 ### Libraries
@@ -93,6 +93,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Web Audio Metronome](https://github.com/cwilso/metronome) - metronome app that uses the Web Audio scheduler and setTimeout scheduler
 - [EarSketch](https://earsketch.gatech.edu/landing/#/) - free educational programming environment to teach Python and Javascript through music composing and remixing
 - [webaudio-tinysynth](https://github.com/g200kg/webaudio-tinysynth) - a small synthesizer written in JavaScript with GM like timbre map.
+- [ToolKnit MIDI Keyboard](https://toolknit.com/tools/midi-keyboard.html) - Browser-based virtual MIDI keyboard using Web Audio API and Web MIDI API. Play instruments directly in your browser with no installation required.
 - [web-audio-beat-detector](https://github.com/meerasndr/sample-golang-app) - a beat detection utility which is using the Web Audio API
 - [web-audio-mixer](https://github.com/jamesfiltness/web-audio-mixer) - An audio mixer built using Web Audio.
 - [Audio-motion interface](https://github.com/MaxAlyokhin/audio-motion-interface) - A web synthesizer that generates sound using smartphone gestures in the space.
@@ -100,9 +101,9 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Online Sequencer](https://onlinesequencer.net) - A simple and easy-to-use sequencer with plenty of functionality, based around the Web Audio API.
 - [Binary Synth](https://github.com/MaxAlyokhin/binary-synth) - A web-synthesizer that generates sound from the binary code of any files.
 - [dsssp-demo](https://github.com/NumberOneBot/dsssp-demo) - WebAudio music player with 7-bands EQ and filter presets.
-- [SingMeter](https://www.singmeter.com/) â€“ A collection of browser-based singing tools including a pitch detector and vocal range test.
-- [Drumhaus](https://drumha.us/) â€“ a browser-based drum machine with step sequencing, pattern variations, and groove editing.
-- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) â€“ Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
+- [SingMeter](https://www.singmeter.com/) ¨C A collection of browser-based singing tools including a pitch detector and vocal range test.
+- [Drumhaus](https://drumha.us/) ¨C a browser-based drum machine with step sequencing, pattern variations, and groove editing.
+- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) ¨C Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [Tonalux](https://tonalux.org) - Free browser-based audio analysis suite with real-time spectrum analyzer, LUFS loudness metering (EBU R128), A/B reference comparison and stereo correlation. Built with Web Audio API and WebAssembly, runs entirely client-side.
 - [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser. 
@@ -159,7 +160,7 @@ Projects without activity since January 2019 or officially dead.
 - [playnote](https://github.com/createbits/playnote) - Play your favorite instrument in the browser, with complex note intervals and scales.
 - [Recorderjs](https://github.com/mattdiamond/Recorderjs) - A plugin for recording/exporting the output of Web Audio API nodes.
 - [resampler](https://github.com/notthetup/resampler) - A utility for resampling audio.
-- [bpm-detective](https://github.com/tornqvist/bpm-detective) â€“ Detects the BPM of a song or audio sample.
+- [bpm-detective](https://github.com/tornqvist/bpm-detective) ¨C Detects the BPM of a song or audio sample.
 - [web-audio-utils](https://github.com/mohayonao/web-audio-utils) - Commonly needed utility functions for Web Audio API.
 - [web-audio-oscillators](https://github.com/lukehorvat/web-audio-oscillators) - A collection of Web Audio custom oscillators.
 - [midi-ports](https://github.com/AndrejHronco/midi-ports) - handy library to make it easier to work with attached MIDI devices.

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Bap](https://github.com/adamrenklint/bap) - A toolkit for making beats and composing sequences, inspired by the classic MPC60/2000.
 - [Omnitone](https://github.com/GoogleChrome/omnitone) - Ambisonic spatial audio on the web.
 - [Mach1Spatial](https://github.com/Mach1Studios/m1-sdk) - Vector based panning spatial audio on the web.
-- [Elementary](https://www.elementary.audio/) 每?Declarative, functional framework for writing audio software on the web or for native apps
+- [Elementary](https://www.elementary.audio/) - ?Declarative, functional framework for writing audio software on the web or for native apps
 - [React Native Audio API](https://github.com/software-mansion-labs/react-native-audio-api) - Web Audio API implementation for native apps based on react-native.
 
 ### Libraries
@@ -101,9 +101,9 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Online Sequencer](https://onlinesequencer.net) - A simple and easy-to-use sequencer with plenty of functionality, based around the Web Audio API.
 - [Binary Synth](https://github.com/MaxAlyokhin/binary-synth) - A web-synthesizer that generates sound from the binary code of any files.
 - [dsssp-demo](https://github.com/NumberOneBot/dsssp-demo) - WebAudio music player with 7-bands EQ and filter presets.
-- [SingMeter](https://www.singmeter.com/) 每 A collection of browser-based singing tools including a pitch detector and vocal range test.
-- [Drumhaus](https://drumha.us/) 每 a browser-based drum machine with step sequencing, pattern variations, and groove editing.
-- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) 每 Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
+- [SingMeter](https://www.singmeter.com/) -  A collection of browser-based singing tools including a pitch detector and vocal range test.
+- [Drumhaus](https://drumha.us/) -  a browser-based drum machine with step sequencing, pattern variations, and groove editing.
+- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) -  Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [Tonalux](https://tonalux.org) - Free browser-based audio analysis suite with real-time spectrum analyzer, LUFS loudness metering (EBU R128), A/B reference comparison and stereo correlation. Built with Web Audio API and WebAssembly, runs entirely client-side.
 - [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser. 
@@ -160,7 +160,7 @@ Projects without activity since January 2019 or officially dead.
 - [playnote](https://github.com/createbits/playnote) - Play your favorite instrument in the browser, with complex note intervals and scales.
 - [Recorderjs](https://github.com/mattdiamond/Recorderjs) - A plugin for recording/exporting the output of Web Audio API nodes.
 - [resampler](https://github.com/notthetup/resampler) - A utility for resampling audio.
-- [bpm-detective](https://github.com/tornqvist/bpm-detective) 每 Detects the BPM of a song or audio sample.
+- [bpm-detective](https://github.com/tornqvist/bpm-detective) -  Detects the BPM of a song or audio sample.
 - [web-audio-utils](https://github.com/mohayonao/web-audio-utils) - Commonly needed utility functions for Web Audio API.
 - [web-audio-oscillators](https://github.com/lukehorvat/web-audio-oscillators) - A collection of Web Audio custom oscillators.
 - [midi-ports](https://github.com/AndrejHronco/midi-ports) - handy library to make it easier to work with attached MIDI devices.

--- a/readme.md
+++ b/readme.md
@@ -101,9 +101,9 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Online Sequencer](https://onlinesequencer.net) - A simple and easy-to-use sequencer with plenty of functionality, based around the Web Audio API.
 - [Binary Synth](https://github.com/MaxAlyokhin/binary-synth) - A web-synthesizer that generates sound from the binary code of any files.
 - [dsssp-demo](https://github.com/NumberOneBot/dsssp-demo) - WebAudio music player with 7-bands EQ and filter presets.
-- [SingMeter](https://www.singmeter.com/) -  A collection of browser-based singing tools including a pitch detector and vocal range test.
-- [Drumhaus](https://drumha.us/) -  a browser-based drum machine with step sequencing, pattern variations, and groove editing.
-- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) -  Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
+- [SingMeter](https://www.singmeter.com/) - A collection of browser-based singing tools including a pitch detector and vocal range test.
+- [Drumhaus](https://drumha.us/) - a browser-based drum machine with step sequencing, pattern variations, and groove editing.
+- [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) - Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [Tonalux](https://tonalux.org) - Free browser-based audio analysis suite with real-time spectrum analyzer, LUFS loudness metering (EBU R128), A/B reference comparison and stereo correlation. Built with Web Audio API and WebAssembly, runs entirely client-side.
 - [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser. 
@@ -160,7 +160,7 @@ Projects without activity since January 2019 or officially dead.
 - [playnote](https://github.com/createbits/playnote) - Play your favorite instrument in the browser, with complex note intervals and scales.
 - [Recorderjs](https://github.com/mattdiamond/Recorderjs) - A plugin for recording/exporting the output of Web Audio API nodes.
 - [resampler](https://github.com/notthetup/resampler) - A utility for resampling audio.
-- [bpm-detective](https://github.com/tornqvist/bpm-detective) -  Detects the BPM of a song or audio sample.
+- [bpm-detective](https://github.com/tornqvist/bpm-detective) - Detects the BPM of a song or audio sample.
 - [web-audio-utils](https://github.com/mohayonao/web-audio-utils) - Commonly needed utility functions for Web Audio API.
 - [web-audio-oscillators](https://github.com/lukehorvat/web-audio-oscillators) - A collection of Web Audio custom oscillators.
 - [midi-ports](https://github.com/AndrejHronco/midi-ports) - handy library to make it easier to work with attached MIDI devices.


### PR DESCRIPTION
## ToolKnit MIDI Keyboard

Adding [ToolKnit MIDI Keyboard](https://toolknit.com/tools/midi-keyboard.html) to the Apps section.

### Why it fits awesome-webaudio:
- Uses **Web Audio API** for sound synthesis (oscillators, gain nodes, effects)
- Uses **Web MIDI API** for MIDI device connectivity
- Runs entirely in the browser, no installation needed
- Free to use with no registration

### Demo
https://toolknit.com/tools/midi-keyboard.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed README title by removing a stray leading character and normalized dash/spacing around several links.
  * Added "ToolKnit MIDI Keyboard" to the Apps list.
  * Updated dash/spacing formatting for multiple app entries (dsssp-demo, SingMeter, Drumhaus, All-in-One Advanced BPM Tool) and an obsolete app entry for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->