### PR TITLE
Add Tonalux Audio Analyzer (open source, in-browser)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [Drumhaus](https://drumha.us/) – a browser-based drum machine with step sequencing, pattern variations, and groove editing.
 - [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) – Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
-- [Tonalux](https://tonalux.org) - Free browser-based audio analysis suite with real-time spectrum analyzer, LUFS loudness metering (EBU R128), A/B reference comparison and stereo correlation. Built with Web Audio API and WebAssembly, runs entirely client-side.
+- [Tonalux](https://tonalux.org) - Open source (MIT) browser audio analysis suite: real-time spectrum, LUFS (EBU R128), A/B reference comparison, stereo correlation. Web Audio + WebAssembly, 100% client-side. [Source](https://github.com/Exenye/tonalux-analyzer).
 - [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser. 
 
 ## Resources


### PR DESCRIPTION
Adds the **Tonalux Audio Analyzer** — a free, open-source (MIT) audio analyzer that runs 100% in the browser, no upload: LUFS / EBU R128, True Peak, BPM, key, spectrum and stereo correlation.

Live: https://tonalux.org/analyzer.html
Source: https://github.com/Exenye/tonalux-analyzer

Happy to adjust formatting/section if needed.