### PR TITLE
Add Cadence to Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,8 @@ Please raise a [Pull-Request](https://github.com/notthetup/awesome-webaudio/pull
 - [All-in-One Advanced BPM Tool](https://tapbpmhub.com/) – Instantly measure song speed by tapping or using the spacebar. Features MIDI input, optional sound clicks, and real-time BPM visualization. Essential for producers, DJs, rhythm gamers.
 - [synflow](https://synflow.org) [Github](https://github.com/k1ln/synflow) - a browser based modular synth flow engine. With all Web Audio API nodes and more with Worklets (like Vocoder, Reverb, etc. ). With sophisticated Flow automation.
 - [Tonalux](https://tonalux.org) - Free browser-based audio analysis suite with real-time spectrum analyzer, LUFS loudness metering (EBU R128), A/B reference comparison and stereo correlation. Built with Web Audio API and WebAssembly, runs entirely client-side.
-- [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser. 
+- [mdrone](https://mdrone.org) - Microtonal drone instrument that runs in your browser.
+- [Cadence](https://cadencetutor.com) - Vocal training in the browser: real-time pitch detection, vocal range and voice type tests, and a sight-singing trainer. Runs entirely client-side on an AudioWorklet, with no upload and no sign-up.
 
 ## Resources
 


### PR DESCRIPTION
https://cadencetutor.com

Vocal training that runs entirely in the browser. Pitch detection is autocorrelation with parabolic interpolation running in an AudioWorklet, so all the analysis is client-side: no audio is uploaded and there is no server doing DSP.

It draws your pitch in real time as you sing, showing where you scoop into a note, where you drift on a long one and how steady the pitch actually is. Alongside the main app there are free vocal range, voice type, tone-deaf, perfect pitch and vibrato tests, none of which need a sign-up, plus a sight-singing trainer and MusicXML import for learning a choir part.

Added to the bottom of the Apps category, as an individual pull request for a single suggestion, with a link to the project in the commit body.

One note on the diff: the editor stripped a trailing space from the mdrone line above, which is why that line shows as modified. Glad to restore it if you would prefer the diff to be a single added line.